### PR TITLE
Set homepage tab title to just "Critical Mass Princeton"

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useRouter } from 'next/router'
 import { DocsThemeConfig } from 'nextra-theme-docs'
 
 const config: DocsThemeConfig = {
@@ -16,9 +17,11 @@ const config: DocsThemeConfig = {
     </>
   ),
   useNextSeoProps() {
-    return {
-      titleTemplate: '%s – Critical Mass Princeton',
+    const { asPath } = useRouter()
+    if (asPath === '/') {
+      return { title: 'Critical Mass Princeton' }
     }
+    return { titleTemplate: '%s – Critical Mass Princeton' }
   },
   docsRepositoryBase: 'https://github.com/ethinallen/cmp-nextra',
   footer: {


### PR DESCRIPTION
Use useRouter to detect the index page and return a plain title instead of the titleTemplate, avoiding the redundant "Welcome to Critical Mass Princeton – Critical Mass Princeton".