### PR TITLE
Improve WhenAndWhere styling and readability

### DIFF
--- a/components/WhenAndWhere.tsx
+++ b/components/WhenAndWhere.tsx
@@ -24,16 +24,43 @@ const WhenAndWhere = () => {
     setDate(lastFriday.toLocaleDateString(undefined, options));
   }, []);
 
+  const linkStyle = {
+    color: '#3b82f6',
+    textDecoration: 'underline',
+    textUnderlineOffset: '2px',
+  };
+
   return (
-    <div>
-      <h2>When and Where</h2>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      <h2 style={{ fontSize: '1.5rem', fontWeight: 700, letterSpacing: '-0.02em' }}>When and Where</h2>
+
       <p>We meet on the <u>last Friday of every month</u> at 6:30 PM and roll out at 7:00 PM.</p>
-      <h3><p><b>Next meeting date:</b> <u>{date}</u></p></h3>
-      <p>Location: <a href="https://maps.google.com/?q=Hinds+Plaza,+Princeton,+NJ" target="_blank" rel="noopener noreferrer">Hinds Plaza</a></p>
-      <p>Or open in:
-        <a href="https://maps.google.com/?q=Hinds+Plaza,+Princeton,+NJ" target="_blank" rel="noopener noreferrer">Google Maps</a> |
-        <a href="https://www.bing.com/maps?q=Hinds+Plaza,+Princeton,+NJ" target="_blank" rel="noopener noreferrer">Bing Maps</a> |
-        <a href="https://www.openstreetmap.org/search?query=Hinds%20Plaza%2C%20Princeton%2C%20NJ" target="_blank" rel="noopener noreferrer">OpenStreetMap</a>
+
+      <p style={{ fontSize: '1.125rem' }}>
+        <b>Next meeting date:</b>{' '}
+        <u>{date}</u>
+      </p>
+
+      <p>
+        📍 Location:{' '}
+        <a href="https://maps.google.com/?q=Hinds+Plaza,+Princeton,+NJ" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          Hinds Plaza
+        </a>
+      </p>
+
+      <p>
+        Open in:{' '}
+        <a href="https://maps.google.com/?q=Hinds+Plaza,+Princeton,+NJ" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          Google Maps
+        </a>
+        {' · '}
+        <a href="https://www.bing.com/maps?q=Hinds+Plaza,+Princeton,+NJ" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          Bing Maps
+        </a>
+        {' · '}
+        <a href="https://www.openstreetmap.org/search?query=Hinds%20Plaza%2C%20Princeton%2C%20NJ" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          OpenStreetMap
+        </a>
       </p>
     </div>
   );


### PR DESCRIPTION
Add vertical spacing between elements, larger heading for visual hierarchy, blue underlined links to denote clickability, proper spacing between map provider links, and a pin emoji for location.